### PR TITLE
Change to download the archive from GitHub Releases instead of dl.bintray

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV JAVA_OPTS=-Danalyzer.assembly.dotnet.path=/usr/bin/dotnet -Danalyzer.bundle.
 
 COPY --from=jlink /jlinked /opt/jdk/
 
-RUN wget -O /tmp/current.txt https://jeremylong.github.io/DependencyCheck/current.txt && current=$(cat /tmp/current.txt) && wget https://dl.bintray.com/jeremy-long/owasp/dependency-check-$current-release.zip && unzip dependency-check-$current-release.zip && mv dependency-check /usr/share/
+RUN wget -O /tmp/current.txt https://jeremylong.github.io/DependencyCheck/current.txt && current=$(cat /tmp/current.txt) && wget https://github.com/jeremylong/DependencyCheck/releases/download/v${current}/dependency-check-${current}-release.zip && unzip dependency-check-${current}-release.zip && mv dependency-check /usr/share/
 
 VOLUME "/src"
 VOLUME "/reports"


### PR DESCRIPTION
Hello,

It seems there is no archive of the latest version (i.e. 6.1.2) in https://dl.bintray.com/jeremy-long/owasp/. Due to this, the GitHub Action has been failing.
So this commit changes to use GitHub Releases of [jeremylong/DependencyCheck](https://github.com/jeremylong/DependencyCheck) to download the archive, instead.